### PR TITLE
Kalle/publisher date format

### DIFF
--- a/harvester/sharekit/extraction.py
+++ b/harvester/sharekit/extraction.py
@@ -2,6 +2,7 @@ import re
 from mimetypes import guess_type
 from hashlib import sha1
 from dateutil.parser import parse as date_parser
+from datetime import datetime
 from itertools import chain
 
 from django.conf import settings
@@ -191,6 +192,14 @@ class SharekitMetadataExtraction(ExtractProcessor):
         return publisher_datetime.year
 
     @classmethod
+    def get_publisher_date(cls, node):
+        publisher_date = node["attributes"].get("publishedAt", None)
+        if not publisher_date:
+            return
+        publisher_datetime = date_parser(publisher_date, default=datetime(year=1970, month=1, day=1))
+        return publisher_datetime.strftime("%Y-%m-%d")
+
+    @classmethod
     def get_lom_educational_levels(cls, node):
         educational_levels = node["attributes"].get("educationalLevels", [])
         if not educational_levels:
@@ -300,7 +309,7 @@ SHAREKIT_EXTRACTION_OBJECTIVE = {
     "provider": SharekitMetadataExtraction.get_provider,
     "organizations": SharekitMetadataExtraction.get_organizations,
     "publishers": SharekitMetadataExtraction.get_publishers,
-    "publisher_date": "$.attributes.publishedAt",
+    "publisher_date": SharekitMetadataExtraction.get_publisher_date,
     "publisher_year": SharekitMetadataExtraction.get_publisher_year,
     "lom_educational_levels": SharekitMetadataExtraction.get_lom_educational_levels,
     "lowest_educational_level": SharekitMetadataExtraction.get_lowest_educational_level,

--- a/harvester/sharekit/fixtures/sharekit-api.initial.0.json
+++ b/harvester/sharekit/fixtures/sharekit-api.initial.0.json
@@ -25,7 +25,7 @@
                 "title": "Exercises 5",
                 "subtitle": null,
                 "publishers": "SURFnet",
-                "publishedAt": "1970-01-01",
+                "publishedAt": "1970-12-11",
                 "place": null,
                 "abstract": "Fifth exercises of the course",
                 "keywords": [
@@ -554,7 +554,7 @@
                 "title": "03. What are little big histories?",
                 "subtitle": null,
                 "publishers": "SURFnet",
-                "publishedAt": "2016-11-22",
+                "publishedAt": null,
                 "place": null,
                 "abstract": "Video about the question 'What are little big histories?' By creating a little big history you can explore big history in a structured an systematic way. Link big history to something close to you and make distant eventss and processes come to life. The concept of little big history makes it easy to come up with your own new ideas.",
                 "keywords": [
@@ -635,7 +635,7 @@
                 "title": "04. Can big history reunify all our knowledge?",
                 "subtitle": null,
                 "publishers": "SURFnet",
-                "publishedAt": "2016-11-22",
+                "publishedAt": "2016",
                 "place": null,
                 "abstract": "Video about the question 'Can big history reunify all our knowledge?' What to leave out and what not? We can make these decisions based on theories: mental constructs that can help us order reality. What is required for the development of complexity? You need energy flows through matter and you need very good circumstances. This theory is underlying all of natural science. But how can we connect all theories, including history, psychology etc. There is a major challenge here.",
                 "keywords": [

--- a/harvester/sharekit/tests/test_get_harvest_seeds.py
+++ b/harvester/sharekit/tests/test_get_harvest_seeds.py
@@ -207,3 +207,9 @@ class TestGetHarvestSeedsSharekit(SeedExtractionTestCase):
         seeds = self.seeds
         self.assertEqual(seeds[0]["publisher_year"], 1970)
         self.assertIsNone(seeds[8]["publisher_year"], "Expected deleted material to have no publisher year")
+
+    def test_get_publisher_date(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["publisher_date"], "1970-12-11")
+        self.assertIsNone(seeds[6]["publisher_date"])
+        self.assertEqual(seeds[7]["publisher_date"], "2016-01-01")

--- a/harvester/sources/extraction/buas.py
+++ b/harvester/sources/extraction/buas.py
@@ -174,6 +174,20 @@ class BuasMetadataExtraction(ExtractProcessor):
             case "ClosedAccess", _:
                 return False
 
+    @classmethod
+    def get_publisher_date(cls, node):
+        current_publication = next(
+            (publication for publication in node["publicationStatuses"] if publication["current"]),
+            None
+        )
+        if not current_publication:
+            return
+        publication_date = current_publication["publicationDate"]
+        year = publication_date["year"]
+        month = publication_date.get("month", 1)
+        day = publication_date.get("day", 1)
+        return f"{year}-{month:02}-{day:02}"
+
 
 BuasMetadataExtraction.OBJECTIVE = {
     # Essential NPPO properties
@@ -189,7 +203,7 @@ BuasMetadataExtraction.OBJECTIVE = {
     "provider": BuasMetadataExtraction.get_provider,
     "organizations": BuasMetadataExtraction.get_organizations,
     "publishers": BuasMetadataExtraction.get_publishers,
-    "publisher_date": lambda node: None,
+    "publisher_date": BuasMetadataExtraction.get_publisher_date,
     "publisher_year": "$.publicationStatuses.0.publicationDate.year",
 
     # Non-essential NPPO properties

--- a/harvester/sources/extraction/edurep.py
+++ b/harvester/sources/extraction/edurep.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from mimetypes import guess_type
 from hashlib import sha1
 from core.constants import HIGHER_EDUCATION_LEVELS
@@ -272,7 +273,7 @@ class EdurepMetadataExtraction(ExtractProcessor):
         date_string = cls.get_publisher_date(node)
         if not date_string:
             return
-        date = date_parser(date_string, dayfirst=True)
+        date = date_parser(date_string, dayfirst=True, default=datetime(year=1970, month=1, day=1))
         return date.strftime('%Y-%m-%d')
 
     @classmethod

--- a/harvester/sources/extraction/greeni.py
+++ b/harvester/sources/extraction/greeni.py
@@ -1,6 +1,7 @@
 import os
 import re
 from hashlib import sha1
+from datetime import datetime
 from dateutil.parser import ParserError, parse as date_parser
 
 import vobject
@@ -229,6 +230,15 @@ class GreeniDataExtraction(object):
         return [publisher.text.strip()] if publisher else []
 
     @classmethod
+    def get_publisher_date(cls, soup, el):
+        date_issued = el.find("dateIssued")
+        if not date_issued:
+            return
+        return \
+            date_parser(date_issued.text.strip().strip("[]"), default=datetime(year=1970, month=1, day=1))\
+            .strftime("%Y-%m-%d")
+
+    @classmethod
     def get_publisher_year(cls, soup, el):
         date_issued = el.find("dateIssued")
         if not date_issued:
@@ -301,7 +311,7 @@ GREENI_EXTRACTION_OBJECTIVE = {
     "provider": GreeniDataExtraction.get_provider,
     "organizations": GreeniDataExtraction.get_organizations,
     "publishers": GreeniDataExtraction.get_publishers,
-    "publisher_date": lambda soup, el: None,
+    "publisher_date": GreeniDataExtraction.get_publisher_date,
     "publisher_year": GreeniDataExtraction.get_publisher_year,
 
     # Non-essential NPPO properties

--- a/harvester/sources/extraction/hku.py
+++ b/harvester/sources/extraction/hku.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from mimetypes import guess_type
 from hashlib import sha1
 from dateutil.parser import parse as date_parser
@@ -154,8 +155,16 @@ class HkuMetadataExtraction(ExtractProcessor):
 
     @classmethod
     def get_publisher_year(cls, node):
-        datetime = date_parser(node["date"])
-        return datetime.year
+        date = date_parser(node["date"])
+        return date.year
+
+    @classmethod
+    def get_publisher_date(cls, node):
+        publisher_date = node.get("date", None)
+        if not publisher_date:
+            return
+        publisher_datetime = date_parser(publisher_date, default=datetime(year=1970, month=1, day=1))
+        return publisher_datetime.strftime("%Y-%m-%d")
 
     @classmethod
     def get_provider(cls, node):
@@ -212,7 +221,7 @@ HKU_EXTRACTION_OBJECTIVE = {
     "provider": HkuMetadataExtraction.get_provider,
     "organizations": HkuMetadataExtraction.get_organizations,
     "publishers": HkuMetadataExtraction.get_publishers,
-    "publisher_date": lambda node: None,
+    "publisher_date": HkuMetadataExtraction.get_publisher_date,
     "publisher_year": HkuMetadataExtraction.get_publisher_year,
 
     # Non-essential NPPO properties

--- a/harvester/sources/extraction/hva.py
+++ b/harvester/sources/extraction/hva.py
@@ -193,6 +193,20 @@ class HvaMetadataExtraction(ExtractProcessor):
         except IndexError:
             return None
 
+    @classmethod
+    def get_publisher_date(cls, node):
+        current_publication = next(
+            (publication for publication in node["publicationStatuses"] if publication["current"]),
+            None
+        )
+        if not current_publication:
+            return
+        publication_date = current_publication["publicationDate"]
+        year = publication_date["year"]
+        month = publication_date.get("month", 1)
+        day = publication_date.get("day", 1)
+        return f"{year}-{month:02}-{day:02}"
+
 
 HVA_EXTRACTION_OBJECTIVE = {
     # Essential NPPO properties
@@ -208,7 +222,7 @@ HVA_EXTRACTION_OBJECTIVE = {
     "provider": HvaMetadataExtraction.get_provider,
     "organizations": HvaMetadataExtraction.get_organizations,
     "publishers": HvaMetadataExtraction.get_publishers,
-    "publisher_date": lambda node: None,
+    "publisher_date": HvaMetadataExtraction.get_publisher_date,
     "publisher_year": "$.publicationStatuses.0.publicationDate.year",
 
     # Non-essential NPPO properties

--- a/harvester/sources/extraction/publinova.py
+++ b/harvester/sources/extraction/publinova.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from mimetypes import guess_type
 from hashlib import sha1
 from dateutil.parser import parse as date_parser
@@ -126,8 +127,16 @@ class PublinovaMetadataExtraction(ExtractProcessor):
         published_at = node.get("published_at", None)
         if published_at is None:
             return
-        datetime = date_parser(published_at)
-        return datetime.year
+        date = date_parser(published_at)
+        return date.year
+
+    @classmethod
+    def get_publisher_date(cls, node):
+        published_at = node.get("published_at", None)
+        if published_at is None:
+            return
+        date = date_parser(published_at, default=datetime(year=1970, month=1, day=1))
+        return date.strftime('%Y-%m-%d')
 
     @classmethod
     def get_is_restricted(cls, node):
@@ -179,7 +188,7 @@ PUBLINOVA_EXTRACTION_OBJECTIVE = {
     "provider": PublinovaMetadataExtraction.get_provider,
     "organizations": PublinovaMetadataExtraction.get_organizations,
     "publishers": PublinovaMetadataExtraction.get_publishers,
-    "publisher_date": "$.published_at",
+    "publisher_date": PublinovaMetadataExtraction.get_publisher_date,
     "publisher_year": PublinovaMetadataExtraction.get_publisher_year,
 
     # # Non-essential NPPO properties

--- a/harvester/sources/extraction/saxion.py
+++ b/harvester/sources/extraction/saxion.py
@@ -1,6 +1,7 @@
 import os
 import re
 from hashlib import sha1
+from datetime import datetime
 from dateutil.parser import ParserError, parse as date_parser
 
 import vobject
@@ -226,7 +227,7 @@ class SaxionDataExtraction(object):
         date_issued = el.find("dateIssued")
         if not date_issued:
             return
-        return date_issued.text.strip()
+        return date_parser(date_issued.text.strip(), default=datetime(year=1970, month=1, day=1)).strftime("%Y-%m-%d")
 
     @classmethod
     def get_publisher_year(cls, soup, el):

--- a/harvester/sources/tests/extraction/test_buas.py
+++ b/harvester/sources/tests/extraction/test_buas.py
@@ -110,3 +110,8 @@ class TestGetHarvestSeedsBuas(TestCase):
     def test_research_object_type(self):
         seeds = self.seeds
         self.assertEqual(seeds[0]["research_object_type"], "Article")
+
+    def test_publisher_date(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["publisher_date"], "2012-06-07")
+        self.assertEqual(seeds[9]["publisher_date"], "2010-01-14")

--- a/harvester/sources/tests/extraction/test_greeni.py
+++ b/harvester/sources/tests/extraction/test_greeni.py
@@ -109,6 +109,11 @@ class TestGetHarvestSeedsGreeni(TestCase):
         self.assertEqual(seeds[1]["publisher_year"], 2012)
         self.assertIsNone(seeds[2]["publisher_year"], "Expected parse errors to be ignored")
 
+    def test_publisher_date(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["publisher_date"], "2010-01-01")
+        self.assertEqual(seeds[1]["publisher_date"], "2012-11-02")
+
     def test_research_object_type(self):
         seeds = self.seeds
         self.assertEqual(seeds[0]["research_object_type"], "info:eu-repo/semantics/book")

--- a/harvester/sources/tests/extraction/test_hku.py
+++ b/harvester/sources/tests/extraction/test_hku.py
@@ -109,3 +109,8 @@ class TestGetHarvestSeedsHku(TestCase):
     def test_publisher_year(self):
         seeds = self.seeds
         self.assertEqual(seeds[0]["publisher_year"], 2014)
+
+    def test_get_publisher_date(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["publisher_date"], "2014-04-14")
+        self.assertEqual(seeds[7]["publisher_date"], "2008-04-01")

--- a/harvester/sources/tests/extraction/test_hva.py
+++ b/harvester/sources/tests/extraction/test_hva.py
@@ -121,3 +121,9 @@ class TestGetHarvestSeedsHva(TestCase):
         seeds = self.seeds
         self.assertIsNone(seeds[0]["doi"])
         self.assertEqual(seeds[5]["doi"], "10.1088/0031-+9120/+50/5/573")
+
+    def test_publisher_date(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["publisher_date"], "2016-01-01")
+        self.assertEqual(seeds[1]["publisher_date"], "2016-02-01")
+        self.assertIsNone(seeds[5]["publisher_date"])

--- a/harvester/sources/tests/extraction/test_publinova.py
+++ b/harvester/sources/tests/extraction/test_publinova.py
@@ -95,6 +95,11 @@ class TestGetHarvestSeedsPublinova(TestCase):
         seeds = self.seeds
         self.assertEqual(seeds[0]["publisher_year"], 2023)
 
+    def test_get_publisher_date(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["publisher_date"], "2023-03-01")
+        self.assertEqual(seeds[1]["publisher_date"], "2022-09-24")
+
     def test_get_doi(self):
         seeds = self.seeds
         self.assertEqual(seeds[0]["doi"], "10.5117/THRM2019.3.VETH")

--- a/harvester/sources/tests/extraction/test_saxion.py
+++ b/harvester/sources/tests/extraction/test_saxion.py
@@ -109,6 +109,7 @@ class TestGetHarvestSeedsSaxion(TestCase):
     def test_publisher_date(self):
         seeds = self.seeds
         self.assertEqual(seeds[0]["publisher_date"], "2020-01-01")
+        self.assertEqual(seeds[1]["publisher_date"], "2020-01-01")
         self.assertIsNone(self.deleted["publisher_date"])
 
     def test_publisher_year(self):


### PR DESCRIPTION
Year extraction in data format YYYY-mm-dd has been implemented and/or fixed for the following sources:
- Sharekit
- edurep
- greeni
- hku
- hva
- saxion
- buas

Not changed is the following:
- han has weird fixture problems
- Anatomy tool does not have issues
- publinova is from publinova so they really should implement their own source right? nvm im gonna implement it anyway give me a sec