### PR TITLE
Fako/promote indices

### DIFF
--- a/harvester/core/admin/datatypes.py
+++ b/harvester/core/admin/datatypes.py
@@ -10,6 +10,7 @@ from admin_confirm.admin import confirm_action
 from datagrowth.admin import DataStorageAdmin, DocumentAdmin as DatagrowthDocumentAdmin
 
 from search.clients import get_opensearch_client
+from core.tasks.commands import promote_dataset_version
 
 
 class HarvestObjectMixinAdmin(object):
@@ -65,8 +66,8 @@ class DatasetVersionAdmin(AdminConfirmMixin, HarvestObjectMixinAdmin, admin.Mode
         if queryset.count() > 1:
             messages.error(request, "Can't promote more than one dataset version at a time")
             return
-        # dataset_version = queryset.first()
-        # promote_dataset_version.delay(dataset_version.id)
+        dataset_version = queryset.first()
+        promote_dataset_version.delay(dataset_version.id, dataset_version._meta.app_label)
         messages.info(request, "A job to switch the dataset version has been dispatched. "
                                "Please refresh the page in a couple of minutes to see the results.")
 

--- a/harvester/core/apps.py
+++ b/harvester/core/apps.py
@@ -5,6 +5,7 @@ from datagrowth.configuration import register_defaults
 
 class CoreConfig(AppConfig):
     name = 'core'
+    document_model = 'Document'
 
     def ready(self):
 

--- a/harvester/core/management/commands/promote_dataset_version.py
+++ b/harvester/core/management/commands/promote_dataset_version.py
@@ -2,7 +2,7 @@ import logging
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from core.models import Dataset, DatasetVersion
+from core.loading import load_harvest_models
 
 
 logger = logging.getLogger("harvester")
@@ -14,12 +14,18 @@ class Command(BaseCommand):
         parser.add_argument('-d', '--dataset', type=str, default="")
         parser.add_argument('-hv', '--harvester-version', type=str, default=settings.VERSION)
         parser.add_argument('-i', '--dataset-version-id', type=int, default=0)
+        parser.add_argument('-a', '--app-label', type=str, default="core")
 
     def handle(self, *args, **options):
 
         dataset_version_id = options["dataset_version_id"]
         dataset_name = options["dataset"]
         harvester_version = options["harvester_version"]
+        app_label = options["app_label"]
+
+        models = load_harvest_models(app_label)
+        Dataset = models["Dataset"]
+        DatasetVersion = models["DatasetVersion"]
 
         if not dataset_version_id and not dataset_name:
             raise CommandError("Dataset name required if dataset version id is not specified")
@@ -35,10 +41,18 @@ class Command(BaseCommand):
 
         logger.info(f"Promoting: {dataset_version.dataset.name}, {dataset_version.version} (id={dataset_version.id})")
 
-        for index in dataset_version.indices.all():
-            logger.info(f"Promoting index { index.remote_name } to latest")
-            index.promote_to_latest()
+        if getattr(dataset_version, "indices", None):
+            for index in dataset_version.indices.all():
+                logger.info(f"Promoting index { index.remote_name } to latest")
+                index.promote_to_latest()
+            dataset_version.set_current()
+        elif getattr(dataset_version, "index", None):
+            index = dataset_version.index
+            logger.info(f"Promoting index { index.name } to latest")
+            dataset_version.index.promote_all_to_latest()  # when merging languages into one index we can remove "all"
+            dataset_version.set_index_promoted()
+            dataset_version.set_current()
+        else:
+            raise CommandError("Unexpected DatasetVersion interface: neither indices nor index is available")
 
-        dataset_version.set_current()
-
-        logger.info("Finished promoting indices")
+        logger.info("Finished promoting")

--- a/harvester/core/models/search/index.py
+++ b/harvester/core/models/search/index.py
@@ -97,8 +97,10 @@ class ElasticIndex(models.Model):
         # The index pattern should target all datasets and versions,
         # but stay clear from targeting protected AWS indices to prevent errors
         index_pattern = f"*-*-*-{alias_prefix}-{self.language}"
+        new_pattern = f"{alias_prefix}-products--*-*-{self.language}"
         try:
             self.client.indices.delete_alias(index=index_pattern, name=alias)
+            self.client.indices.delete_alias(index=new_pattern, name=alias)
         except NotFoundError:
             pass
         self.client.indices.put_alias(index=self.remote_name, name=alias)

--- a/harvester/core/models/search/index.py
+++ b/harvester/core/models/search/index.py
@@ -100,6 +100,9 @@ class ElasticIndex(models.Model):
         new_pattern = f"{alias_prefix}-products--*-*-{self.language}"
         try:
             self.client.indices.delete_alias(index=index_pattern, name=alias)
+        except NotFoundError:
+            pass
+        try:
             self.client.indices.delete_alias(index=new_pattern, name=alias)
         except NotFoundError:
             pass

--- a/harvester/core/tasks/commands.py
+++ b/harvester/core/tasks/commands.py
@@ -8,5 +8,8 @@ def clean_data():
 
 
 @app.task(name="promote_dataset_version")
-def promote_dataset_version(dataset_version_id):
-    call_command("promote_dataset_version", f"--dataset-version-id={dataset_version_id}")
+def promote_dataset_version(dataset_version_id, app_label="core"):
+    call_command(
+        "promote_dataset_version",
+        f"--dataset-version-id={dataset_version_id}", f"--app-label={app_label}"
+    )

--- a/harvester/search/models/index.py
+++ b/harvester/search/models/index.py
@@ -107,9 +107,11 @@ class OpenSearchIndex(models.Model):
         # but stay clear from deleting cross project and cross language indices to prevent data loss
         # as well as targeting protected AWS indices to prevent errors
         index_pattern = f"{alias_prefix}--*-*-{language}"
+        legacy_pattern = f"*-*-*-{alias_prefix}-{language}"
         try:
             self.client.indices.delete_alias(index=index_pattern, name=alias)
             self.client.indices.delete_alias(index=index_pattern, name=legacy_alias)
+            self.client.indices.delete_alias(index=legacy_pattern, name=legacy_alias)
         except NotFoundError:
             pass
         if self.check_remote_exists(language):

--- a/harvester/search/models/index.py
+++ b/harvester/search/models/index.py
@@ -107,7 +107,7 @@ class OpenSearchIndex(models.Model):
         # but stay clear from deleting cross project and cross language indices to prevent data loss
         # as well as targeting protected AWS indices to prevent errors
         index_pattern = f"{alias_prefix}--*-*-{language}"
-        legacy_pattern = f"*-*-*-{alias_prefix}-{language}"
+        legacy_pattern = f"*-*-*-{settings.OPENSEARCH_ALIAS_PREFIX}-{language}"
         try:
             self.client.indices.delete_alias(index=index_pattern, name=alias)
             self.client.indices.delete_alias(index=index_pattern, name=legacy_alias)

--- a/harvester/search/models/index.py
+++ b/harvester/search/models/index.py
@@ -95,6 +95,10 @@ class OpenSearchIndex(models.Model):
         self.save()
         return errors
 
+    def promote_all_to_latest(self) -> None:
+        for language in settings.OPENSEARCH_LANGUAGE_CODES:
+            self.promote_to_latest(language)
+
     def promote_to_latest(self, language: str) -> None:
         alias_prefix, dataset_info = self.name.split("--")
         alias = f"{alias_prefix}-{language}"

--- a/harvester/search/models/index.py
+++ b/harvester/search/models/index.py
@@ -111,12 +111,15 @@ class OpenSearchIndex(models.Model):
         try:
             self.client.indices.delete_alias(index=index_pattern, name=alias)
             self.client.indices.delete_alias(index=index_pattern, name=legacy_alias)
-            self.client.indices.delete_alias(index=legacy_pattern, name=legacy_alias)
         except NotFoundError:
             pass
         if self.check_remote_exists(language):
             self.client.indices.put_alias(index=self.get_remote_name(language), name=alias)
             self.client.indices.put_alias(index=self.get_remote_name(language), name=legacy_alias)
+            try:
+                self.client.indices.delete_alias(index=legacy_pattern, name=legacy_alias)
+            except NotFoundError:
+                pass
 
     def clean(self) -> None:
         if not self.configuration:

--- a/harvester/search/tasks/index.py
+++ b/harvester/search/tasks/index.py
@@ -28,6 +28,7 @@ def _push_dataset_version_to_index(dataset_version: HarvestDatasetVersion,
             index.pushed_at = current_time
             index.save()
     except DatabaseError:
+        index = None
         logger.warning("Unable to acquire a database lock for sync_opensearch_indices")
     return index
 


### PR DESCRIPTION
This PR allows to promote indices for a DatasetVersion from the admin. Promoting a DatasetVersion means creating the correct aliases for relevant indices. These aliases get used for search by the frontend. So if the DatasetVersion from last night turns out to be problematic it's now possible to "rollback" to the previous DatasetVersion, meaning that the alias will point to an index without problems.

Also this PR fixes this problem: https://github.com/surfedushare/harvester/issues/191. The new harvest and old harvest run side by side during a transition period, but when promoting an index it wouldn't delete old aliases, meaning that frontends would search through the old and indices. Oops.