### PR TITLE
Sets EdurepOAIPMH record state based on record header or educational level (allowing MBO)

### DIFF
--- a/harvester/core/constants.py
+++ b/harvester/core/constants.py
@@ -58,18 +58,18 @@ HARVEST_STAGE_CHOICES = [
 
 
 HIGHER_EDUCATION_LEVELS = {
-    "BVE": 1,
     "HBO": 2,
-    "HBO - Bachelor": 2,
-    "HBO - Master": 2,
     "WO": 3,
-    "WO - Bachelor": 3,
-    "WO - Master": 3,
 }
 
+MBO_EDUCATIONAL_LEVELS = {
+    "BVE",
+    "MBO",
+    "Beroepsonderwijs en Volwasseneneducatie",
+    "Volwasseneneducatie",
+}
 
 SITE_SHORTHAND_BY_DOMAIN = {
     "harvester.prod.surfedushare.nl": "edusources",
-    "harvester.mbo.prod.surfedushare.nl": "mbo",
     "harvester.publinova.nl": "publinova",
 }

--- a/harvester/edurep/fixtures/edurep-oaipmh.initial.0.xml
+++ b/harvester/edurep/fixtures/edurep-oaipmh.initial.0.xml
@@ -139,9 +139,9 @@
                                 </czp:entry>
                             </czp:taxon>
                             <czp:taxon>
-                                <czp:id>f33b30ee-3c82-4ead-bc20-4255be9ece2d</czp:id>
+                                <czp:id>f35b30ee-3c82-4ead-bc20-4255be9ece2d</czp:id>
                                 <czp:entry>
-                                    <czp:langstring xml:lang="nl">HBO - Bachelor</czp:langstring>
+                                    <czp:langstring xml:lang="nl">MBO</czp:langstring>
                                 </czp:entry>
                             </czp:taxon>
                         </czp:taxonpath>
@@ -340,9 +340,9 @@
                                 </czp:entry>
                             </czp:taxon>
                             <czp:taxon>
-                                <czp:id>18656a7c-95a5-4831-8085-020d3151aceb</czp:id>
+                                <czp:id>aaaaaa7c-95a5-4831-8085-020d3151aceb</czp:id>
                                 <czp:entry>
-                                    <czp:langstring xml:lang="nl">WO - Bachelor</czp:langstring>
+                                    <czp:langstring xml:lang="nl">Groep 3</czp:langstring>
                                 </czp:entry>
                             </czp:taxon>
                         </czp:taxonpath>
@@ -604,15 +604,9 @@ END:VCARD</czp:vcard></czp:centity>
                                 </czp:langstring>
                             </czp:source>
                             <czp:taxon>
-                                <czp:id>be140797-803f-4b9e-81cc-5572c711e09c</czp:id>
+                                <czp:id>f35b30ee-3c82-4ead-bc20-4255be9ece2d</czp:id>
                                 <czp:entry>
-                                    <czp:langstring xml:lang="nl">HBO</czp:langstring>
-                                </czp:entry>
-                            </czp:taxon>
-                            <czp:taxon>
-                                <czp:id>f33b30ee-3c82-4ead-bc20-4255be9ece2d</czp:id>
-                                <czp:entry>
-                                    <czp:langstring xml:lang="nl">HBO - Bachelor</czp:langstring>
+                                    <czp:langstring xml:lang="nl">MBO</czp:langstring>
                                 </czp:entry>
                             </czp:taxon>
                         </czp:taxonpath>

--- a/harvester/edurep/tests/test_get_harvest_seeds.py
+++ b/harvester/edurep/tests/test_get_harvest_seeds.py
@@ -37,7 +37,7 @@ class TestGetHarvestSeedsEdurep(SeedExtractionTestCase):
 
     def test_get_complete_set_without_deletes(self):
         seeds = get_harvest_seeds(Repositories.EDUREP, self.set_spec, self.begin_of_time, include_deleted=False)
-        self.assertEqual(len(seeds), 9)
+        self.assertEqual(len(seeds), 7)
         self.check_seed_integrity(seeds, include_deleted=False)
 
     def test_get_partial_set_without_deletes(self):
@@ -119,19 +119,10 @@ class TestGetHarvestSeedsEdurep(SeedExtractionTestCase):
         seeds = self.seeds
         self.assertEqual(seeds[0]["lom_educational_levels"], [],
                          "Expected deleted materials to have no educational level")
-        self.assertEqual(sorted(seeds[1]["lom_educational_levels"]), ["HBO", "HBO - Bachelor"],
+        self.assertEqual(sorted(seeds[9]["lom_educational_levels"]), ["HBO", "HBO - Bachelor"],
                          "Expected HBO materials to have an educational level")
-        self.assertEqual(sorted(seeds[2]["lom_educational_levels"]), ["WO", "WO - Bachelor"],
-                         "Expected HBO materials to have an educational level")
-
-    def test_lowest_educational_level(self):
-        seeds = self.seeds
-        self.assertEqual(seeds[0]["lowest_educational_level"], -1,
-                         "Expected deleted materials to have negative educational level")
-        self.assertEqual(seeds[1]["lowest_educational_level"], 2,
-                         "Expected HBO materials to have an educational level of 2")
-        self.assertEqual(seeds[2]["lowest_educational_level"], 3,
-                         "Expected HBO materials to have an educational level of 3")
+        self.assertEqual(sorted(seeds[13]["lom_educational_levels"]), ["WO", "WO - Bachelor"],
+                         "Expected WO materials to have an educational level")
 
     def test_get_files(self):
         seeds = self.seeds
@@ -200,3 +191,12 @@ class TestGetHarvestSeedsEdurep(SeedExtractionTestCase):
                           "Expected material without publication date to have no publication year")
         self.assertEqual(seeds[3]["publisher_year"], 2017)
         self.assertEqual(seeds[8]["publisher_year"], 2020)
+
+    def test_get_oaipmh_record_state(self):
+        seeds = self.seeds
+        self.assertEqual(seeds[0]["state"], "deleted", "Expected deleted material to have state deleted")
+        self.assertEqual(seeds[1]["state"], "active", "Expected MBO level with HBO level to be active")
+        self.assertEqual(seeds[2]["state"], "inactive", "Expected Groep 3 level to always be inactive")
+        self.assertEqual(seeds[3]["state"], "inactive", "Expected MBO level to be inactive without any higher levels")
+        self.assertEqual(seeds[9]["state"], "active", "Expected HBO level to be active")
+        self.assertEqual(seeds[13]["state"], "active", "Expected WO level to be active")

--- a/harvester/package.py
+++ b/harvester/package.py
@@ -1,5 +1,5 @@
 PACKAGE = {
-    "version": "1.39.28",
+    "version": "1.39.33",
     "name": "harvester",
     "cpu": "2048",
 }

--- a/harvester/sources/tests/extraction/test_edurep.py
+++ b/harvester/sources/tests/extraction/test_edurep.py
@@ -39,16 +39,6 @@ class TestGetHarvestSeedsEdurep(TestCase):
             else:
                 self.assertEqual(state, "active")
 
-    def test_lowest_education_level(self):
-        seeds = self.seeds
-
-        self.assertEqual(seeds[0]["lowest_educational_level"], 1,
-                         "Expected file with MBO to have lowest educational level 1")
-        self.assertEqual(seeds[1]["lowest_educational_level"], 1,
-                         "Expected file with MBO to have lowest educational level 1")
-        self.assertEqual(seeds[2]["lowest_educational_level"], 2,
-                         "Expected file with HBO to have lowest educational level 2")
-
     def test_keywords(self):
         seeds = self.seeds
         self.assertTrue("asperge" in seeds[0]["keywords"])


### PR DESCRIPTION
This PR is perhaps conflicting with the Edurep refactor. It's good to double check this. The ticket to include MBO level under the condition that a material is also HBO or WO tagged and not tagged with anything lower than MBO like "Groep 3" is relatively new. The demo is Monday however and I will be demoing this on acceptance without actually merging to give you a chance to adopt your work. Sorry that the tickets are crossing in this way, but we'll figure it out together is that helps.