### PR TITLE
Adds the approach and results fields for Hogeschool Utrecht

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install git+https://github.com/surfedushare/search-client.git@v0.6.31
+        pip install git+https://github.com/surfedushare/search-client.git@v0.6.32-a
     - name: Setup repository
       run: |
         invoke aws.sync-repository-state --no-profile

--- a/harvester/Dockerfile
+++ b/harvester/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install -U --no-cache-dir --user pip
 RUN pip install wheel
 RUN pip install --no-cache-dir --user uwsgi==2.0.24
 RUN pip install --no-cache-dir --user -r requirements.txt
-RUN pip install --no-cache-dir --user git+https://github.com/surfedushare/search-client.git@v0.6.31
+RUN pip install --no-cache-dir --user git+https://github.com/surfedushare/search-client.git@v0.6.32-a
 
 # Copy application
 COPY harvester /usr/src/app

--- a/harvester/projects/constants.py
+++ b/harvester/projects/constants.py
@@ -11,6 +11,8 @@ SEED_DEFAULTS = {
     "ended_at": None,
     "coordinates": [],
     "goal": None,
+    "approach": None,
+    "results": None,
     "persons": [],
     "keywords": [],
     "products": [],

--- a/harvester/projects/fixtures/test-project-document.json
+++ b/harvester/projects/fixtures/test-project-document.json
@@ -82,6 +82,8 @@
             "set": "buas:project",
             "srn": "buas:project:133ce0c9-9dd6-44b8-b798-3b524f17bce0",
             "goal": null,
+            "approach": null,
+            "results": null,
             "state": "active",
             "title": "K2K Consortium development zero-emissions tourism mobility",
             "persons": [

--- a/harvester/projects/tests/views/test_project.py
+++ b/harvester/projects/tests/views/test_project.py
@@ -32,6 +32,8 @@ class TestProjectView(TestCase):
         "ended_at": "2019-12-31",
         "coordinates": [],
         "goal": None,
+        "approach": None,
+        "results": None,
         "keywords": [
             "Zero-emissions",
             "tourism",

--- a/harvester/projects/views/serializers.py
+++ b/harvester/projects/views/serializers.py
@@ -28,6 +28,8 @@ class ProjectSerializer(serializers.Serializer):
         validators=[MinLengthValidator(0), MaxLengthValidator(2)]
     )
     goal = serializers.CharField(allow_null=True, allow_blank=True)
+    approach = serializers.CharField(allow_null=True, allow_blank=True)
+    results = serializers.CharField(allow_null=True, allow_blank=True)
     keywords = serializers.ListField(child=serializers.CharField())
     products = serializers.ListField(child=serializers.CharField())
     previews = serializers.DictField(default=None, allow_null=True)


### PR DESCRIPTION
Currently these fields have no value, because HU hasn't been added to the repo yet. This PR adds the defaults. It needs to do that in a few places:
* The entity defaults in constants.py
* The API endpoint serializers
* The test fixture and API endpoint tests

Apart from this we need to update the search-client to pull in changes that might be shared with other services through that library. See PR for that here: https://github.com/surfedushare/search-client/pull/125

NB: we're not yet using search-client serializers directly, but there are plans to do this if we decide to switch to this Django variant of FastAPI: https://django-ninja.dev/
