### PR TITLE
Fako/stop sources

### DIFF
--- a/environments/edusources.yml
+++ b/environments/edusources.yml
@@ -19,9 +19,6 @@ django:
   users:
     usernames: "arn:aws:secretsmanager:eu-central-1:{account}:secret:users/edusources"
 
-harvester:
-  sources_middleware_api: null
-
 conext:
   is_enabled: false
   client_id: none

--- a/environments/localhost/invoke.yml
+++ b/environments/localhost/invoke.yml
@@ -24,7 +24,7 @@ harvester:
     edurep: "https://staging.edurep.kennisnet.nl"
     sharekit: "https://api.acc.surfsharekit.nl"
     han: "https://repository.han.nl"
-    hva: "https://accpure.hva.nl"
+    hva: "https://pure.hva.nl"
     hanze: "https://apimanagement.hanze.nl"
     publinova: "https://api.publinova.acc.surf.zooma.cloud"
     hu: "https://hu.nl"

--- a/environments/mbodata.yml
+++ b/environments/mbodata.yml
@@ -19,9 +19,6 @@ django:
   users:
     usernames: "arn:aws:secretsmanager:eu-central-1:{account}:secret:users/edusources"
 
-harvester:
-  sources_middleware_api: null
-
 opensearch:
   strict_multilingual_fields: true
 

--- a/environments/publinova.yml
+++ b/environments/publinova.yml
@@ -20,9 +20,6 @@ django:
   users:
     usernames: "arn:aws:secretsmanager:eu-central-1:{account}:secret:users/publinova"
 
-harvester:
-  sources_middleware_api: "https://sources.{environment_code}.publinova.nl/api/v1/"
-
 conext:
   client_id: "harvester.prod.publinova.nl"
 

--- a/harvester/files/models/datatypes/file.py
+++ b/harvester/files/models/datatypes/file.py
@@ -21,39 +21,52 @@ from files.models.resources.metadata import CheckURLResource
 
 def default_document_tasks():
     return {
+        # Incoming data that is invalid should deactivate the document.
+        # Other tasks may execute, but document will never be outputted to frontends.
+        # As this task depends only on the incoming data it runs on every document.
         "deactivate_invalid_documents": {
             "depends_on": ["$.hash", "$.access_rights"],  # these properties are important for (output) serializers
             "checks": [],
             "resources": []
         },
+
+        # There are pre-publish tasks that check existence of URL's, download content and resolve redirects.
+        # These are non-Youtube only, because YouTube requires separate API based processing.
         "check_url": {
             "depends_on": ["$.hash"],
             "checks": ["!is_not_found", "is_analysis_allowed", "!is_youtube_video"],
             "resources": ["files.CheckURLResource"]
         },
-        "tika": {
+        "publish_content": {
             "depends_on": ["$.hash", "check_url"],
             "checks": ["is_analysis_possible"],
+            "resources": ["files.MirrorFileResource"]
+        },
+
+        # These are post-publish tasks. The public_url is assumed to be available to work with.
+        "tika": {
+            "depends_on": ["$.hash", "publish_content"],
+            "checks": ["is_published"],
             "resources": ["files.HttpTikaResource"]
         },
         "pdf_preview": {
-            "depends_on": ["$.hash", "check_url"],
-            "checks": ["is_analysis_possible", "is_pdf"],
+            "depends_on": ["$.hash", "publish_content"],
+            "checks": ["is_published", "is_pdf"],
             "resources": ["files.PdfThumbnailResource"]
         },
         "image_preview": {
-            "depends_on": ["$.hash", "check_url"],
-            "checks": ["is_analysis_possible", "is_image"],
+            "depends_on": ["$.hash", "publish_content"],
+            "checks": ["is_published", "is_image"],
             "resources": ["files.ImageThumbnailResource"]
         },
         "video_preview": {
-            "depends_on": [],
-            "checks": ["is_analysis_possible", "is_video", "!is_youtube_video"],
+            "depends_on": ["$.hash", "publish_content"],
+            "checks": ["is_published", "is_video"],
             "resources": ["files.VideoThumbnailResource"]
         },
         "video_transcripts": {
-            "depends_on": [],
-            "checks": ["is_analysis_possible", "is_video", "!is_youtube_video"],
+            "depends_on": ["$.hash", "publish_content"],
+            "checks": ["is_published", "is_video"],
             "resources": ["files.VideoTranscriptsResource"]
         },
 
@@ -163,6 +176,11 @@ class FileDocument(HarvestDocument):
         check_url = self.derivatives.get("check_url", {})
         status = check_url.get("status")
         return status is not None and 200 <= status < 209
+
+    @property
+    def is_published(self):
+        publish_content = self.task_results.get("publish_content", {})
+        return publish_content.get("success", False)
 
     def get_analysis_allowed(self) -> bool:
         match self.properties.get("access_rights", None), self.properties.get("copyright", None):

--- a/harvester/files/models/resources/metadata.py
+++ b/harvester/files/models/resources/metadata.py
@@ -1,5 +1,6 @@
 import logging
 import json
+from urllib3.util import parse_url
 from urllib3.exceptions import LocationParseError
 from requests.exceptions import InvalidURL
 
@@ -56,6 +57,18 @@ class HttpTikaResource(HttpResource):
 
 
 class CheckURLResource(URLResource):
+
+    def auth_headers(self):
+        scheme, auth, host, port, path, query, fragment = parse_url(self.request["url"])
+        if host.endswith("hanze.nl"):
+            return {
+                "Ocp-Apim-Subscription-Key": settings.SOURCES["hanze"]["api_key"]
+            }
+        elif host.endswith("hva.nl"):
+            return {
+                "api-key": settings.SOURCES["hva"]["api_key"]
+            }
+        return {}
 
     def _update_from_results(self, response):
         self.head = dict(response.headers.lower_items())

--- a/harvester/files/sources/hanze.py
+++ b/harvester/files/sources/hanze.py
@@ -1,12 +1,18 @@
+from django.conf import settings
+
 from sources.utils.pure import build_seeding_phases
 from sources.models import HanzeResearchObjectResource
 from files.sources.pure import PureFileExtraction, build_objective
 
 
 class HanzeFileExtractor(PureFileExtraction):
-    pure_api_prefix = "/nppo/"
     source_slug = "hanze"
     source_name = "Hanze"
+
+    @classmethod
+    def parse_file_url(cls, url):
+        hanze_middleware_endpoint = f"{settings.SOURCES["hanze"]["endpoint"]}/nppo/"
+        return url.replace("https://research.hanze.nl/ws/api/", hanze_middleware_endpoint)
 
 
 OBJECTIVE = build_objective(HanzeFileExtractor, "hanze:hanze")

--- a/harvester/files/sources/hva.py
+++ b/harvester/files/sources/hva.py
@@ -4,7 +4,6 @@ from files.sources.pure import PureFileExtraction, build_objective
 
 
 class HvAFileExtractor(PureFileExtraction):
-    pure_api_prefix = "/ws/api/"
     source_slug = "hva"
 
 

--- a/harvester/files/sources/pure.py
+++ b/harvester/files/sources/pure.py
@@ -46,7 +46,7 @@ class PureFileExtraction(PureExtractor):
     def get_url(cls, info: ElectronicVersionInfo) -> str:
         url_property = "url" if info.is_link else cls.file_url_property
         normalized_url = cls.parse_url(info.data[url_property])
-        return cls._parse_file_url(normalized_url)
+        return cls.parse_file_url(normalized_url)
 
     @classmethod
     def get_hash(cls, info: ElectronicVersionInfo) -> str:

--- a/harvester/files/tasks/metadata.py
+++ b/harvester/files/tasks/metadata.py
@@ -141,7 +141,7 @@ def tika_task(app_label: str, document_ids: list[int]) -> None:
             "tika_return_type": "xml",
             "resource": "files.httptikaresource",
             "method": "put",
-            "args": ["$.url"],
+            "args": ["$.public_url"],
             "kwargs": {},
         },
         "contribute_data": {

--- a/harvester/files/tasks/previews.py
+++ b/harvester/files/tasks/previews.py
@@ -20,7 +20,7 @@ def video_preview(app_label: str, document_ids: list[int]):
         "asynchronous": False,
         "retrieve_data": {
             "resource": "files.videothumbnailresource",
-            "args": ["$.url"],
+            "args": ["$.public_url"],
             "kwargs": {},
         },
         "contribute_data": {
@@ -84,7 +84,7 @@ def pdf_preview(app_label: str, document_ids: list[int]):
         "retrieve_data": {
             "resource": "files.pdfthumbnailresource",
             "method": "get",
-            "args": ["$.url"],
+            "args": ["$.public_url"],
             "kwargs": {},
         },
         "contribute_data": {
@@ -116,7 +116,7 @@ def image_preview(app_label: str, document_ids: list[int]):
         "retrieve_data": {
             "resource": "files.imagethumbnailresource",
             "method": "get",
-            "args": ["$.url"],
+            "args": ["$.public_url"],
             "kwargs": {},
         },
         "contribute_data": {

--- a/harvester/files/tests/seeding/test_hanze.py
+++ b/harvester/files/tests/seeding/test_hanze.py
@@ -10,7 +10,6 @@ from sources.factories.hanze.extraction import HanzeResearchObjectResourceFactor
 from testing.cases import seeding
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHanzeFileSeeding(seeding.FactorySeedingTestCase):
 
     entity = "files"
@@ -26,7 +25,7 @@ class TestHanzeFileSeeding(seeding.FactorySeedingTestCase):
 
     def test_delta_seeding(self, *args):
         documents = super().test_delta_seeding([
-            "hanze:hanze:ffffffff-3115-41bb-9d73-2a193da652ea:34c9d2735ae055acb66f3cd85c996a84efd12842",
+            "hanze:hanze:ffffffff-3115-41bb-9d73-2a193da652ea:87763635119aebfcdcb4721e076c563f4591be17",
         ])
         self.assertEqual(len(documents), 8, "Expected test to work with single page for the delta")
         self.assertEqual(
@@ -50,7 +49,6 @@ class TestHanzeFileSeeding(seeding.FactorySeedingTestCase):
         )
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHanzeFileExtraction(TestCase):
 
     set = None
@@ -84,7 +82,7 @@ class TestHanzeFileExtraction(TestCase):
     def test_get_external_id(self):
         self.assertEqual(
             self.seeds[0]["external_id"],
-            "01ea0ee1-a419-42ee-878b-439b44562098:01df6be8b59f65074350ca33c8eded52ea106222"
+            "01ea0ee1-a419-42ee-878b-439b44562098:dcb29c3c24db4ca313ef7662eec7284be4bde029"
         )
 
     def test_get_language(self):
@@ -94,13 +92,13 @@ class TestHanzeFileExtraction(TestCase):
     def test_get_url(self):
         self.assertEqual(
             self.seeds[0]["url"],
-            "http://testserver/api/v1/files/hanze/research-outputs/01ea0ee1-a419-42ee-878b-439b44562098/"
+            "https://apimanagement.hanze.nl/nppo/research-outputs/01ea0ee1-a419-42ee-878b-439b44562098/"
             "files/NWU1MWM2/wtnr2_verh1_p99_113_HR_v2_Inter_nationale_ervaringen"
             "_met_ondergrondse_infiltratievoorzieningen_20_jaar.pdf"
         )
 
     def test_get_hash(self):
-        self.assertEqual(self.seeds[0]["hash"], "01df6be8b59f65074350ca33c8eded52ea106222")
+        self.assertEqual(self.seeds[0]["hash"], "dcb29c3c24db4ca313ef7662eec7284be4bde029")
 
     def test_get_mime_type(self):
         self.assertEqual(self.seeds[0]["mime_type"], "application/pdf")

--- a/harvester/files/tests/seeding/test_hva.py
+++ b/harvester/files/tests/seeding/test_hva.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from datagrowth.configuration import register_defaults
 from core.constants import DeletePolicies
@@ -25,7 +25,7 @@ class TestHvAFileSeeding(seeding.FactorySeedingTestCase):
 
     def test_delta_seeding(self, *args):
         documents = super().test_delta_seeding([
-            "hva:hva:f6b1feec-b7f1-442a-9a49-1da4cbb3646a:484cf5228fad26faec3c382b410c228a8bdfe5e1",
+            "hva:hva:f6b1feec-b7f1-442a-9a49-1da4cbb3646a:dfa3dda07a92eb0d56bc8d48f74a7605ed4e8acd",
         ])
         self.assertEqual(len(documents), 6, "Expected test to work with single page for the delta")
         self.assertEqual(
@@ -47,7 +47,6 @@ class TestHvAFileSeeding(seeding.FactorySeedingTestCase):
         )
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHvaFileExtraction(TestCase):
 
     set = None
@@ -81,7 +80,7 @@ class TestHvaFileExtraction(TestCase):
     def test_get_external_id(self):
         self.assertEqual(
             self.seeds[0]["external_id"],
-            "d7126f6d-c412-43c8-ad2a-6acb7613917d:f5052b0d0d801fcd313c4395f963ab332ab3a521"
+            "d7126f6d-c412-43c8-ad2a-6acb7613917d:7f7df20bbcbc19d061345684dcb30cfd52976a44"
         )
         self.assertEqual(
             self.seeds[3]["external_id"],
@@ -97,7 +96,7 @@ class TestHvaFileExtraction(TestCase):
         seeds = self.seeds
         self.assertEqual(
             seeds[0]["url"],
-            "http://testserver/api/v1/files/hva/research-outputs/d7126f6d-c412-43c8-ad2a-6acb7613917d/files/MDIyMzRi/"
+            "https://pure.hva.nl/ws/api/research-outputs/d7126f6d-c412-43c8-ad2a-6acb7613917d/files/MDIyMzRi/"
             "636835_schuldenvrij-de-weg-naar-werk_aangepast.pdf"
         )
         self.assertEqual(
@@ -106,7 +105,7 @@ class TestHvaFileExtraction(TestCase):
         )
 
     def test_get_hash(self):
-        self.assertEqual(self.seeds[0]["hash"], "f5052b0d0d801fcd313c4395f963ab332ab3a521")
+        self.assertEqual(self.seeds[0]["hash"], "7f7df20bbcbc19d061345684dcb30cfd52976a44")
         self.assertEqual(self.seeds[3]["hash"], "54a95ef8691a8b3ac88759451ac61feeedaa14cf")
 
     def test_get_mime_type(self):

--- a/harvester/files/tests/tasks/test_check_url_task.py
+++ b/harvester/files/tests/tasks/test_check_url_task.py
@@ -1,14 +1,13 @@
 from django.test import TestCase
-from unittest.mock import patch
 
-from datagrowth.configuration import register_defaults
+from datagrowth.resources.testing import EnableGlobalCacheMixin
 
 from files.models import FileDocument
 from files.tasks.metadata import check_url_task
 from files.tests.factories import create_file_document_set
 
 
-class TestCheckURLTask(TestCase):
+class TestCheckURLTask(EnableGlobalCacheMixin, TestCase):
 
     dataset_version = None
     set = None
@@ -18,9 +17,6 @@ class TestCheckURLTask(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        register_defaults("global", {
-            "cache_only": True
-        })
         cls.dataset_version, cls.set, cls.documents = create_file_document_set(
             set_specification="test",
             docs=[{"url": "https://surf.nl"},
@@ -30,15 +26,7 @@ class TestCheckURLTask(TestCase):
         )
         cls.success, cls.fail, = cls.documents
 
-    @classmethod
-    def tearDownClass(cls):
-        register_defaults("global", {
-            "cache_only": False
-        })
-        super().tearDownClass()
-
-    @patch("files.models.resources.metadata.CheckURLResource._send")
-    def test_task(self, send_mock):
+    def test_task(self):
         check_url_task("files", [doc.id for doc in self.documents])
         for doc in FileDocument.objects.all():
             self.assertIn("check_url", doc.task_results)

--- a/harvester/files/tests/tasks/test_document_tasks.py
+++ b/harvester/files/tests/tasks/test_document_tasks.py
@@ -54,11 +54,26 @@ class TestHarvestObjectFileDocument(TestCase):
             "preview_file": "https://i.ytimg.com/vi_webp/t6tUThsvE4M/maxresdefault.webp"
         }
         self.youtube.save()
+        # Assert that tasks depending on check_url or youtube_api have become pending
+        pending_tasks_1 = self.document_1.get_pending_tasks()
+        self.assertEqual(pending_tasks_1, ["publish_content"])
+        youtube_tasks = self.youtube.get_pending_tasks()
+        self.assertEqual(youtube_tasks, ["youtube_preview"])
+
+    def test_get_tertiary_pending_tasks(self):
+        # Set Tika task as completed
+        self.document_1.task_results["check_url"] = {"success": True}
+        self.document_1.derivatives["check_url"] = {"status": 200}
+        self.document_1.task_results["deactivate_invalid_documents"] = {
+            "success": True,
+            "validation": None
+        }
+        self.document_1.task_results["publish_content"] = {"success": True, "is_auto_succeed": True}
+        self.document_1.derivatives["publish_content"] = {"public_url": self.document_1.properties["url"]}
+        self.document_1.save()
         # Assert that tasks depending on Tika have become pending
         pending_tasks_1 = self.document_1.get_pending_tasks()
         self.assertEqual(pending_tasks_1, ["tika"])
-        youtube_tasks = self.youtube.get_pending_tasks()
-        self.assertEqual(youtube_tasks, ["youtube_preview"])
 
     def test_get_analysis_disallowed(self):
         pending_tasks_2 = self.document_2.get_pending_tasks()

--- a/harvester/harvester/settings/base.py
+++ b/harvester/harvester/settings/base.py
@@ -693,7 +693,6 @@ SOURCES = {
         "api_key": environment.secrets.hu.api_key
     }
 }
-SOURCES_MIDDLEWARE_API = environment.harvester.sources_middleware_api
 
 
 # Webhooks

--- a/harvester/organizations/sources/hanze.py
+++ b/harvester/organizations/sources/hanze.py
@@ -5,7 +5,6 @@ from sources.utils.pure import PureExtractor
 
 class HanzeOrganizationExtraction(PureExtractor):
 
-    pure_api_prefix = "/nppo/"
     source_slug = "hanze"
     source_name = "Hanze"
 

--- a/harvester/persons/fixtures/resources/hva-persons.json
+++ b/harvester/persons/fixtures/resources/hva-persons.json
@@ -3,7 +3,7 @@
     "model": "persons.hvapersonresource",
     "pk": 1,
     "fields": {
-        "uri": "accpure.hva.nl/ws/api/persons",
+        "uri": "pure.hva.nl/ws/api/persons",
         "status": 200,
         "config": "{\"_namespace\": \"global\", \"_private\": [\"_private\", \"_defaults\", \"_namespace\"]}",
         "created_at": "2025-04-30T08:08:47.796Z",
@@ -19,7 +19,7 @@
             ],
             "kwargs": {},
             "method": "get",
-            "url": "https://accpure.hva.nl/ws/api/persons",
+            "url": "https://pure.hva.nl/ws/api/persons",
             "headers": {
                 "User-Agent": "DataGrowth (v0.20.6); python-requests/2.32.3",
                 "Accept-Encoding": "gzip, deflate, br",
@@ -56,7 +56,7 @@
     "model": "persons.hvauserresource",
     "pk": 1,
     "fields": {
-        "uri": "accpure.hva.nl/ws/api/users/1fd55bef-58bd-400f-a037-7248a27e44ba",
+        "uri": "pure.hva.nl/ws/api/users/1fd55bef-58bd-400f-a037-7248a27e44ba",
         "status": 200,
         "config": "{\"_namespace\": \"global\", \"_private\": [\"_private\", \"_defaults\", \"_namespace\"]}",
         "created_at": "2025-04-30T08:17:43.478Z",
@@ -71,7 +71,7 @@
             ],
             "kwargs": {},
             "method": "get",
-            "url": "https://accpure.hva.nl/ws/api/users/1fd55bef-58bd-400f-a037-7248a27e44ba",
+            "url": "https://pure.hva.nl/ws/api/users/1fd55bef-58bd-400f-a037-7248a27e44ba",
             "headers": {
                 "User-Agent": "DataGrowth (v0.20.6); python-requests/2.32.3",
                 "Accept-Encoding": "gzip, deflate, br",
@@ -106,7 +106,7 @@
     "model": "persons.hvauserresource",
     "pk": 2,
     "fields": {
-        "uri": "accpure.hva.nl/ws/api/users/6ed3a851-a3df-43f9-8351-562283acce57",
+        "uri": "pure.hva.nl/ws/api/users/6ed3a851-a3df-43f9-8351-562283acce57",
         "status": 200,
         "config": "{\"_namespace\": \"global\", \"_private\": [\"_private\", \"_defaults\", \"_namespace\"]}",
         "created_at": "2025-04-30T08:17:43.478Z",
@@ -121,7 +121,7 @@
             ],
             "kwargs": {},
             "method": "get",
-            "url": "https://accpure.hva.nl/ws/api/users/6ed3a851-a3df-43f9-8351-562283acce57",
+            "url": "https://pure.hva.nl/ws/api/users/6ed3a851-a3df-43f9-8351-562283acce57",
             "headers": {
                 "User-Agent": "DataGrowth (v0.20.6); python-requests/2.32.3",
                 "Accept-Encoding": "gzip, deflate, br",
@@ -156,7 +156,7 @@
     "model": "persons.hvauserresource",
     "pk": 3,
     "fields": {
-        "uri": "accpure.hva.nl/ws/api/users/196fc2a9-318d-47df-bd82-887f6c0c3808",
+        "uri": "pure.hva.nl/ws/api/users/196fc2a9-318d-47df-bd82-887f6c0c3808",
         "status": 200,
         "config": "{\"_namespace\": \"global\", \"_private\": [\"_private\", \"_defaults\", \"_namespace\"]}",
         "created_at": "2025-04-30T08:17:43.478Z",
@@ -171,7 +171,7 @@
             ],
             "kwargs": {},
             "method": "get",
-            "url": "https://accpure.hva.nl/ws/api/users/196fc2a9-318d-47df-bd82-887f6c0c3808",
+            "url": "https://pure.hva.nl/ws/api/users/196fc2a9-318d-47df-bd82-887f6c0c3808",
             "headers": {
                 "User-Agent": "DataGrowth (v0.20.6); python-requests/2.32.3",
                 "Accept-Encoding": "gzip, deflate, br",

--- a/harvester/persons/fixtures/resources/hva/hva-persons.01.json
+++ b/harvester/persons/fixtures/resources/hva/hva-persons.01.json
@@ -7,7 +7,7 @@
     "items": [
         {
             "uuid": "af0b3aa3-054c-4068-9aad-506be254e6e9",
-            "portalUrl": "https://accpure.hva.nl/en/persons/af0b3aa3-054c-4068-9aad-506be254e6e9",
+            "portalUrl": "https://pure.hva.nl/en/persons/af0b3aa3-054c-4068-9aad-506be254e6e9",
             "name": {
                 "firstName": "Pietje",
                 "lastName": "Puk"
@@ -155,7 +155,7 @@
         },
         {
             "uuid": "7a5596ca-272e-4415-9e72-13d2ab494dc7",
-            "portalUrl": "https://accpure.hva.nl/en/persons/7a5596ca-272e-4415-9e72-13d2ab494dc7",
+            "portalUrl": "https://pure.hva.nl/en/persons/7a5596ca-272e-4415-9e72-13d2ab494dc7",
             "prettyUrlIdentifiers": [
                 "lizzy-shizzle"
             ],

--- a/harvester/persons/fixtures/resources/hva/hva-persons.02.json
+++ b/harvester/persons/fixtures/resources/hva/hva-persons.02.json
@@ -7,7 +7,7 @@
     "items": [
         {
             "uuid": "afa498d2-5e47-4672-b840-a2593375e6eb",
-            "portalUrl": "https://accpure.hva.nl/en/persons/af0b3aa3-054c-4068-9aad-506be254e6e9",
+            "portalUrl": "https://pure.hva.nl/en/persons/af0b3aa3-054c-4068-9aad-506be254e6e9",
             "name": {
                 "firstName": "Petra",
                 "lastName": "Puk"
@@ -155,7 +155,7 @@
         },
         {
             "uuid": "7a5596ca-272e-4415-9e72-13d2ab494dc7",
-            "portalUrl": "https://accpure.hva.nl/en/persons/7a5596ca-272e-4415-9e72-13d2ab494dc7",
+            "portalUrl": "https://pure.hva.nl/en/persons/7a5596ca-272e-4415-9e72-13d2ab494dc7",
             "prettyUrlIdentifiers": [
                 "lizzy-shizzle"
             ],

--- a/harvester/persons/sources/hanze.py
+++ b/harvester/persons/sources/hanze.py
@@ -9,7 +9,6 @@ from sources.utils.pure import PureExtractor
 
 class HanzePersonsExtractProcessor(PureExtractor):
 
-    pure_api_prefix = "/nppo/"
     source_name = "Hanze"
     source_slug = "hanze"
 

--- a/harvester/persons/sources/hva.py
+++ b/harvester/persons/sources/hva.py
@@ -7,7 +7,6 @@ from sources.utils.pure import PureExtractor
 
 class HvaPersonsExtractProcessor(PureExtractor):
 
-    pure_api_prefix = "/ws/api/"
     source_name = "Hogeschool van Amsterdam"
     source_slug = "hva"
 

--- a/harvester/products/sources/hanze.py
+++ b/harvester/products/sources/hanze.py
@@ -1,5 +1,7 @@
 from sentry_sdk import capture_message
 
+from django.conf import settings
+
 from sources.utils.pure import build_seeding_phases
 from sources.models import HanzeResearchObjectResource
 from sources.extraction.hanze.research_themes import ASJC_TO_RESEARCH_THEME
@@ -8,10 +10,14 @@ from products.sources.pure import PureProductExtraction, build_objective
 
 class HanzeProductExtractor(PureProductExtraction):
 
-    pure_api_prefix = "/nppo/"
     source_slug = "hanze"
     source_name = "Hanze"
     support_subtitle = True
+
+    @classmethod
+    def parse_file_url(cls, url):
+        hanze_middleware_endpoint = f"{settings.SOURCES["hanze"]["endpoint"]}/nppo/"
+        return url.replace("https://research.hanze.nl/ws/api/", hanze_middleware_endpoint)
 
     @classmethod
     def get_keywords(cls, node):

--- a/harvester/products/sources/hva.py
+++ b/harvester/products/sources/hva.py
@@ -4,7 +4,6 @@ from products.sources.pure import PureProductExtraction, build_objective
 
 
 class HvAProductExtractor(PureProductExtraction):
-    pure_api_prefix = "/ws/api/"
     source_slug = "hva"
     source_name = "Hogeschool van Amsterdam"
 

--- a/harvester/products/sources/pure.py
+++ b/harvester/products/sources/pure.py
@@ -20,7 +20,7 @@ class PureProductExtraction(PureExtractor):
         for electronic_version in electronic_versions:
             if "file" in electronic_version:
                 normalized_url = cls.parse_url(electronic_version["file"][cls.file_url_property])
-                url = cls._parse_file_url(normalized_url)
+                url = cls.parse_file_url(normalized_url)
             elif "link" in electronic_version:
                 url = electronic_version["link"]
             else:

--- a/harvester/products/tests/seeding/test_hanze.py
+++ b/harvester/products/tests/seeding/test_hanze.py
@@ -10,7 +10,6 @@ from sources.factories.hanze.extraction import HanzeResearchObjectResourceFactor
 from testing.cases import seeding
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHanzeProductSeeding(seeding.FactorySeedingTestCase):
 
     entity = "products"
@@ -49,7 +48,6 @@ class TestHanzeProductSeeding(seeding.FactorySeedingTestCase):
         )
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHanzeProductExtraction(TestCase):
 
     set = None
@@ -85,12 +83,12 @@ class TestHanzeProductExtraction(TestCase):
 
     def test_get_files(self):
         self.assertEqual(self.seeds[0]["files"], [
-            "http://testserver/api/v1/files/hanze/research-outputs/01ea0ee1-a419-42ee-878b-439b44562098/"
+            "https://apimanagement.hanze.nl/nppo/research-outputs/01ea0ee1-a419-42ee-878b-439b44562098/"
             "files/NWU1MWM2/wtnr2_verh1_p99_113_HR_v2_Inter_nationale_ervaringen"
             "_met_ondergrondse_infiltratievoorzieningen_20_jaar.pdf",
         ])
         self.assertEqual(self.seeds[12]["files"], [
-            "http://testserver/api/v1/files/hanze/research-outputs/3786d62c-11fa-445b-a299-cc79ea00d468/"
+            "https://apimanagement.hanze.nl/nppo/research-outputs/3786d62c-11fa-445b-a299-cc79ea00d468/"
             "files/MDAxYTdkM2M2/Power_to_the_people_accepted_version_1.pdf",
         ])
 

--- a/harvester/products/tests/seeding/test_hva.py
+++ b/harvester/products/tests/seeding/test_hva.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from datagrowth.configuration import register_defaults
 from core.constants import DeletePolicies
@@ -10,7 +10,6 @@ from sources.factories.hva.extraction import HvaPureResourceFactory
 from testing.cases import seeding
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHvaProductSeeding(seeding.FactorySeedingTestCase):
 
     entity = "products"
@@ -48,7 +47,6 @@ class TestHvaProductSeeding(seeding.FactorySeedingTestCase):
         )
 
 
-@override_settings(SOURCES_MIDDLEWARE_API="http://testserver/api/v1/")
 class TestHvaProductExtraction(TestCase):
 
     set = None
@@ -85,7 +83,7 @@ class TestHvaProductExtraction(TestCase):
         seeds = self.seeds
         self.assertEqual(seeds[0]["files"], [])
         self.assertEqual(seeds[3]["files"], [
-            "http://testserver/api/v1/files/hva/research-outputs/d7126f6d-c412-43c8-ad2a-6acb7613917d/files/"
+            "https://pure.hva.nl/ws/api/research-outputs/d7126f6d-c412-43c8-ad2a-6acb7613917d/files/"
             "MDIyMzRi/636835_schuldenvrij-de-weg-naar-werk_aangepast.pdf",
         ])
 

--- a/harvester/sources/utils/pure.py
+++ b/harvester/sources/utils/pure.py
@@ -1,7 +1,5 @@
 from typing import Type
 
-from django.conf import settings
-
 from datagrowth.resources import HttpResource
 
 from sources.utils.base import BaseExtractor
@@ -14,13 +12,8 @@ class PureExtractor(BaseExtractor):
     source_name = None
 
     @classmethod
-    def _parse_file_url(cls, url):
-        file_path_segment = cls.pure_api_prefix
-        if file_path_segment is None or file_path_segment not in url:
-            return url  # not dealing with a url we recognize as a file url
-        start = url.index(file_path_segment)
-        file_path = url[start + len(file_path_segment):]
-        return f"{settings.SOURCES_MIDDLEWARE_API}files/{cls.source_slug}/{file_path}"
+    def parse_file_url(cls, url):
+        return url
 
     @classmethod
     def get_provider(cls, node):

--- a/harvester/sources/utils/pure.py
+++ b/harvester/sources/utils/pure.py
@@ -7,7 +7,6 @@ from sources.utils.base import BaseExtractor
 
 class PureExtractor(BaseExtractor):
 
-    pure_api_prefix = None
     source_slug = None
     source_name = None
 

--- a/harvester/testing/models/datatypes/document.py
+++ b/harvester/testing/models/datatypes/document.py
@@ -17,9 +17,14 @@ def default_document_tasks():
             "checks": [],
             "resources": ["files.CheckURLResource"]
         },
-        "tika": {
-            "depends_on": ["check_url"],
+        "publish_content": {
+            "depends_on": ["$.url", "check_url"],
             "checks": [],
+            "resources": ["files.MirrorFileResource"]
+        },
+        "tika": {
+            "depends_on": ["$.url", "publish_content"],
+            "checks": ["is_published"],
             "resources": ["files.HttpTikaResource"]
         }
     }
@@ -40,6 +45,11 @@ class TestDocument(HarvestDocument):
                 self.is_not_found = True
                 self.pending_at = None
                 self.finished_at = now()
+
+    @property
+    def is_published(self):
+        publish_content = self.task_results.get("publish_content", {})
+        return publish_content.get("success", False)
 
     def get_analyzer_language(self) -> str:
         return get_analyzer_language(self.properties.get("language", None))

--- a/harvester/testing/tests/harvest/harvest_entities.py
+++ b/harvester/testing/tests/harvest/harvest_entities.py
@@ -155,13 +155,15 @@ class TestDeltaHarvestEntities(HarvestEntitiesTestCase):
         self.no_retry_document = self.documents[4]
         self.no_retry_document.task_results = {
             "check_url": {"success": True},
+            "publish_content": {"success": True},
             "tika": {
                 "success": False,
                 "first_processed_at": "2000-01-01T00:00:00Z"
             }
         }
         self.no_retry_document.derivatives = {
-            "check_url": {"status": 200}
+            "check_url": {"status": 200},
+            "publish_content": {"public_url": "http://testserver/no-retry-url"},
         }
         self.no_retry_document.save()
         for doc in self.documents[5:]:
@@ -272,6 +274,7 @@ class TestDeltaHarvestEntities(HarvestEntitiesTestCase):
             no_retry_document.task_results,
             {
                 "check_url": {"success": True},
+                "publish_content": {"success": True},
                 "tika": {
                     "success": False,
                     "first_processed_at": "2000-01-01T00:00:00Z"
@@ -282,12 +285,13 @@ class TestDeltaHarvestEntities(HarvestEntitiesTestCase):
         self.assertEqual(
             no_retry_document.derivatives,
             {
-                "check_url": {"status": 200}
+                "check_url": {"status": 200},
+                "publish_content": {"public_url": "http://testserver/no-retry-url"},
             },
             "Expected derivatives to remain as is"
         )
         self.assertTrue(no_retry_document.properties, "Expected properties to remain intact")
-        self.assertIsNone(no_retry_document.pending_at, "Expected inactive document to remain unprocessed")
+        self.assertIsNone(no_retry_document.pending_at, "Expected no retry document to remain unprocessed")
         # Success documents
         error_identities = [
             self.invalid_document.identity, self.failed_document.identity, self.unprocessed_document.identity,

--- a/harvester/testing/tests/harvest/test_harvest_source.py
+++ b/harvester/testing/tests/harvest/test_harvest_source.py
@@ -1,12 +1,13 @@
 from unittest.mock import patch
 from copy import copy
 from datetime import datetime
+import pytest
 
 from django.test import TestCase
 from django.utils.timezone import now
 from django.utils.timezone import make_aware
 
-from datagrowth.configuration import register_defaults
+from datagrowth.resources.testing import EnableGlobalCacheMixin
 
 from core.tasks.harvest.source import harvest_source
 from sources.models.harvest import HarvestEntity
@@ -18,23 +19,10 @@ from testing.utils.factories import create_datatype_models
 from testing.models import Dataset, DatasetVersion, HarvestState, Set
 
 
-class TestInitialHarvestSource(TestCase):
+@pytest.mark.slow
+class TestInitialHarvestSource(EnableGlobalCacheMixin, TestCase):
 
     fixtures = ["test-sources-harvest-models"]
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        register_defaults("global", {
-            "cache_only": True
-        })
-
-    @classmethod
-    def tearDownClass(cls):
-        register_defaults("global", {
-            "cache_only": False
-        })
-        super().tearDownClass()
 
     def setUp(self):
         super().setUp()
@@ -76,10 +64,15 @@ class TestInitialHarvestSource(TestCase):
             "Expected no pending documents"
         )
         for ix, doc in enumerate(self.set.documents.all().order_by("created_at")):
-            self.assertEqual(list(doc.task_results.keys()), ["tika", "check_url"])
+            self.assertEqual(list(doc.task_results.keys()), ["tika", "check_url", "publish_content"])
             self.assertTrue(doc.task_results["tika"]["success"])
             self.assertTrue(doc.task_results["check_url"]["success"])
-            self.assertEqual(list(doc.derivatives.keys()), ["tika", "check_url"])
+            self.assertTrue(doc.task_results["publish_content"]["success"])
+            self.assertTrue(
+                doc.task_results["publish_content"]["is_auto_succeed"],
+                "Expected mirror based publishing to be tested by files module"
+            )
+            self.assertEqual(list(doc.derivatives.keys()), ["tika", "check_url", "publish_content"])
             self.assertEqual(doc.derivatives["tika"], {
                 "texts": [f"Tika content for http://testserver/file/{ix}"]
             })
@@ -89,6 +82,9 @@ class TestInitialHarvestSource(TestCase):
                 "content_type": "text/html",
                 "has_redirect": False,
                 "has_temporary_redirect": False
+            })
+            self.assertEqual(doc.derivatives["publish_content"], {
+                "public_url": f"http://testserver/file/{ix}",
             })
         # Assert Set state
         set_instance = Set.objects.get(id=self.set.id)

--- a/harvester/testing/tests/test_document.py
+++ b/harvester/testing/tests/test_document.py
@@ -32,7 +32,7 @@ class TestDocumentModel(TestCase):
     def test_get_property_dependencies(self):
         property_dependencies = self.document.get_property_dependencies()
         self.assertEqual(property_dependencies, {
-            "$.url": ["check_url"]
+            "$.url": ["check_url", "publish_content", "tika"]
         })
 
     def test_invalidate_task(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = harvester.settings
 python_files = test_*.py tests.py __init__.py
+markers =
+    slow: marks tests as slow (skip with --fast)


### PR DESCRIPTION
The tests fail, because this release will change a lot of asserts in Hanze and HvA tests. These are expected failures that will fox themselves once this branch goes to acceptance proper and we push the new fixtures to AWS