### PR TITLE
Update Search Client to 0.7.17

### DIFF
--- a/harvester/Dockerfile
+++ b/harvester/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install -U --no-cache-dir --user pip
 RUN pip install wheel
 RUN pip install --no-cache-dir --user uwsgi==2.0.24
 RUN pip install --no-cache-dir --user -r requirements.txt
-RUN pip install --no-cache-dir --user git+https://github.com/surfedushare/search-client.git@v0.7.14
+RUN pip install --no-cache-dir --user git+https://github.com/surfedushare/search-client.git@0.7.17
 
 # Copy application
 COPY harvester /usr/src/app


### PR DESCRIPTION
    Update Search Client to 0.7.17

    This will be done for the following things:

    * boost more recent articles even more
    * filter publications with files
    * fix explain endpoint

    For more information, see the release notes of the search-client:
    https://github.com/surfedushare/search-client/releases/tag/0.7.17
    and the following PRs:

    * https://github.com/surfedushare/search-client/pull/163
    * https://github.com/surfedushare/search-client/pull/164
    * https://github.com/surfedushare/search-client/pull/166

    Tested this dependency installation by pip installing it locally.                                                                     