### PR TITLE
Bump harvester to 1.45.27

### DIFF
--- a/harvester/package.py
+++ b/harvester/package.py
@@ -1,4 +1,4 @@
 PACKAGE = {
-    "version": "1.45.26",
+    "version": "1.45.27",
     "name": "harvester"
 }


### PR DESCRIPTION
For some reason the 1.45.26 is not tagged correctly.